### PR TITLE
Potential fix for code scanning alert no. 1: Cleartext logging of sensitive information

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -855,7 +855,7 @@ async fn register_user(email: &str, server: &str, username: Option<&str>) -> Res
     let username = email;
     let namespace = email.split('@').next().unwrap_or("user");
     
-    println!("👤 Username: {} (email-based for security)", username);
+    println!("👤 Username will be based on your email for security.");
     println!("🏷️  Namespace: {} (auto-granted access to {}//*)", namespace, namespace);
     
     // Parse server URL to get admin API endpoint


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/orbit/security/code-scanning/1](https://github.com/passadis/orbit/security/code-scanning/1)

In general, to fix cleartext logging of sensitive information, avoid printing or logging raw sensitive fields (credentials, tokens, emails, usernames). If such output is necessary for UX or debugging, either omit the sensitive value or mask/redact it so that the information cannot be misused if logs are exposed.

For this specific function in `src/main.rs`, the `username` is the email, and the email is already printed on line 846. Line 858 adds another print of the same sensitive identifier. The best minimal fix without changing overall behavior is to stop printing the raw `username` there and instead use a generic confirmation message that does not include the email. This preserves feedback (“we’re using your email as username”) while removing the sensitive data from the log sink CodeQL flags.

Concretely:
- In `src/main.rs`, in `register_user`, replace the `println!` on line 858:
  - From: `println!("👤 Username: {} (email-based for security)", username);`
  - To:   `println!("👤 Username will be based on your email for security.");`
- No new imports or helper methods are required; we only change the message string to avoid including the sensitive variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
